### PR TITLE
Add MicroBadger badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LoL Replay
 [![Go Report Card](https://goreportcard.com/badge/github.com/1lann/lol-replay)](https://goreportcard.com/report/github.com/1lann/lol-replay)
 [![GoDoc](https://godoc.org/github.com/1lann/lol-replay?status.svg)](https://godoc.org/github.com/1lann/lol-replay)
-[![Docker Pulls](https://img.shields.io/docker/pulls/1lann/lol-replay.svg?maxAge=2592000)](https://hub.docker.com/r/1lann/lol-replay/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/1lann/lol-replay.svg?maxAge=2592000)](https://hub.docker.com/r/1lann/lol-replay/) [![](https://images.microbadger.com/badges/image/1lann/lol-replay.svg)](https://microbadger.com/images/1lann/lol-replay "Get your own image badge on microbadger.com")
 
 LoL Replay is a collection of Go packages to record and play back League of Legends games from the spectator endpoint. It is designed to be fast, reliable, and efficient. The modular design allows anyone to write their own recording service in Go and manipulate the recording files.
 
@@ -37,3 +37,4 @@ The LoL Replay server is also available as an image on Docker. Refer to the [Doc
 
 ## License
 lol-replay is licensed under the MIT license which can be found [here](/LICENSE).
+ 


### PR DESCRIPTION
We saw your image on Docker Hub at [1lann/lol-replay](https://hub.docker.com/r/1lann/lol-replay/), and we thought you might like this badge for your GitHub readme showing the image contents.

The badge shows the number of layers and download size of your Docker image, and links to our site where you can see the [contents of each layer](https://microbadger.com/images/1lann/lol-replay).

As you're using an automated build it will also show up in your Docker Hub description.

[![](https://images.microbadger.com/badges/image/1lann/lol-replay.svg)](https://microbadger.com/images/1lann/lol-replay)
